### PR TITLE
Fix #134, Support stopping execution with VSCode command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,18 @@ pin = Pin("LED", Pin.OUT)
 
 print("LED starts flashing...")
 while True:
-    pin.toggle()
-    sleep(1) # sleep 1sec
+    try:
+        pin.toggle()
+        sleep(1) # sleep 1sec
+    except KeyboardInterrupt:
+        break
+pin.off()
+print("Finished.")
 ```
+
+- To run your program, run `> MicroPico > Run current file on Pico` in your Python file's tab. You can also use the status bar button "Run " at the bottom of VS Code window.
+
+- To stop the execution of the currently running program, run `> MicroPico > Stop execution`. The "Stop" button at the status bar does the same.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
         "category": "MicroPico"
       },
       {
+        "command": "micropico.universalStop",
+        "title": "Stop execution",
+        "category": "MicroPico"
+      },
+      {
         "command": "micropico.runselection",
         "title": "Run current selection on Pico",
         "enablement": "!inQuickOpen && !listFocus && isFileSystemResource && editorLangId == python",


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
- Exposes `micropico.universalStop` command as the standard(?) VS Code command, which was formerly only used in the status bar button "Stop".
- Add documentation on how to start and stop a program in `README.md`.
- Update the example LED flash program so that it cleanly stops.

## Does this close any currently open issues?
https://github.com/paulober/MicroPico/issues/134

## Any relevant logs, error output, etc?
N/A

## Any other comments?
MicroPico is so nice :)

## Where has this been tested?

**Operating system:**
Windows 10

**VSCode version:**
Version: 1.82.2 (Windows)

See there is a new command `MicroPico: Stop execution`. I can attach a key binding to it. (Ctrl+:, Ctrl+: in this example)
![image](https://github.com/paulober/MicroPico/assets/700034/7a0bcb43-ac01-416d-8f4b-4ac736b1acd8)

I tested the extension [packaged by `vsce`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension), built on Ubuntu 23.4,
https://github.com/eplusx/MicroPico/releases/tag/v3.2.6-stop-execution-command