### PR TITLE
Patch v3.4.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/paulober/MicroPico/blob/main/CHANGELOG.md
     about: Functionality that has changed significantly between versions of MicroPico or known issues.
   - name: Intellisense, auto-complete and linting issues
-    url: https://github.com/paulober/Pico-W-Stub/issues
-    about: These belong in the Pico-W-Stub project rather than MicroPico.
+    url: https://github.com/Josverl/micropython-stubs/issues
+    about: These belong in the Micropython-Stubs project by Josverl rather than MicroPico.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
         run: ./scripts/publish.sh
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
       
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to the "MicroPico" extension will be documented in this file
 
 ---
 
+## [3.4.2] - 2023-11-07
+
+# Changed
+- Upgraded to `pyboard-serial-com` `v2.0.4`, Linux `arm64` and `armhf` releases are now backwards compatible with `GLIBC_2.31` (Fixes #159)
+- Updated dependencies
+- Reload settings before auto-connect to detect settings changes concerning the port
+
 ## [3.4.1] - 2023-10-19
 
 # Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ In order to install `paulober/pyboard-serial-com` sub-package you first have con
 
 ### - Project setup
 - Fork the repository into your private account
-- Create a branch with following naming scheeme `fix-<issue-id>-<short-title-of-the-issue>`
+- Create a branch based on the `develop` branch with following naming scheeme `fix-<issue-id>-<short-title-of-the-issue>`
 - Download your fork of the repository (Github.cli recommended)
-- `cd Pico-W-Go`
+- `cd MicroPico`
 - Switch to your newly created branch (`git checkout <branch-name>` for example)
 - `npm install`
 
@@ -20,4 +20,4 @@ After the fix is complete do some extensive testing if all what could be affecte
 - Now squash all your commits and name the final commit something like `Fix #<issue-id>, <Short title of the issue>`
     - The description of the squash commit should contain a list (description) of all the changes you've made
 
-- Push and create a pull request to the develop branch of paulober/Pico-W-Go
+- Push and create a pull request to the develop branch of paulober/MicroPico

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "linux"
       ],
       "dependencies": {
-        "@paulober/pyboard-serial-com": "^2.0.3",
+        "@paulober/pyboard-serial-com": "^2.0.4",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
         "rimraf": "^5.0.5",
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@paulober/pyboard-serial-com": {
-      "version": "2.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/2.0.3/84884f13db7d2875dc584b78c084174b46933ced",
-      "integrity": "sha512-+6diUJ171h7u8OblJh20a9HTThJwObfu2w/GMpRvOYW2XN4PqI2/0s9aoY9cEtiu4eiegqtfDpDFy7Uy2xALew==",
+      "version": "2.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/2.0.4/c28c41f6696f8f927b3c57ad82080fdbabdec0dc",
+      "integrity": "sha512-Vr85fbuwP9RfmFNC2kP3BUmfoaWH1L+eAogNljcTOHQ63hVwa7ucTC0TANf8lJZwH6mu4+afHhMNL9kS0SfC+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^9.0.1"
@@ -3679,9 +3679,9 @@
       }
     },
     "@paulober/pyboard-serial-com": {
-      "version": "2.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/2.0.3/84884f13db7d2875dc584b78c084174b46933ced",
-      "integrity": "sha512-+6diUJ171h7u8OblJh20a9HTThJwObfu2w/GMpRvOYW2XN4PqI2/0s9aoY9cEtiu4eiegqtfDpDFy7Uy2xALew==",
+      "version": "2.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/2.0.4/c28c41f6696f8f927b3c57ad82080fdbabdec0dc",
+      "integrity": "sha512-Vr85fbuwP9RfmFNC2kP3BUmfoaWH1L+eAogNljcTOHQ63hVwa7ucTC0TANf8lJZwH6mu4+afHhMNL9kS0SfC+g==",
       "requires": {
         "uuid": "^9.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pico-w-go",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pico-w-go",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pico-w-go",
   "displayName": "MicroPico",
   "description": "Auto-completion, remote workspace and a REPL console integration for the Raspberry Pi Pico (W) with MicroPython firmware.",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "publisher": "paulober",
   "license": "MPL-2.0",
   "homepage": "https://github.com/paulober/MicroPico/blob/main/README.md",

--- a/package.json
+++ b/package.json
@@ -527,7 +527,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@paulober/pyboard-serial-com": "^2.0.3",
+    "@paulober/pyboard-serial-com": "^2.0.4",
     "fs-extra": "^11.1.1",
     "lodash": "^4.17.21",
     "rimraf": "^5.0.5",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -38,5 +38,8 @@ done
 
 # Find all .vsix files and publish them one by one
 find . -name "*.vsix" -type f | while read -r package_path; do
+  # Publish the VSCode extension to the VSCode Marketplace
   npx @vscode/vsce publish --packagePath "$package_path"
+  # Publish the VSCode extension to the Open VSX Registry
+  npx ovsx publish "$package_path" -p "$OVSX_PAT"
 done

--- a/src/activator.mts
+++ b/src/activator.mts
@@ -1086,6 +1086,7 @@ export default class Activator {
             return;
           }
           this.ui?.refreshState(false);
+          settings.reload();
           const autoPort = settings.getBoolean(SettingsKey.autoConnect);
 
           const ports = await PyboardRunner.getPorts();

--- a/src/settings.mts
+++ b/src/settings.mts
@@ -30,6 +30,10 @@ export default class Settings {
     this.context = context;
   }
 
+  public reload(): void {
+    this.config = vsWorkspace.getConfiguration(extName);
+  }
+
   public get(key: SettingsKey): Setting {
     return this.config.get(key);
   }


### PR DESCRIPTION
### Changed
- Upgraded to `pyboard-serial-com` `v2.0.4`, Linux `arm64` and `armhf` releases are now backwards compatible with `GLIBC_2.31` (Fixes #159)
- Updated dependencies
- Reload settings before auto-connect to detect settings changes concerning the port