### PR TITLE
Patch v3.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to the "MicroPico" extension will be documented in this file
 
 ---
 
+## [3.7.2] - 2024-01-21
+
+# Added
+- `ESP32-C3` and `Teensy 4.0` support (experimental) (Fixes #96)
+
 ## [3.7.1] - 2024-01-20
 
 # Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MicroPico Visual Studio Code Extension (aka Pico-W-Go)
 
-**New Feature:** Experimental `ESP32-WROOM-32` support! (_Use the `Switch Stubs` command to get auto-completion for the `ESP32` port of MicroPython._)
+**New Feature:** Experimental `ESP32-WROOM-32`, `ESP32-C3` and `Teensy 4.0` support! (_Use the `Switch Stubs` command to get auto-completion for the `ESP32` port of MicroPython._)
 
 **MicroPico** is a Visual Studio Code extension designed to simplify and accelerate the development of MicroPython projects for the Raspberry Pi Pico and Pico W boards. This tool streamlines the coding process, providing code highlighting, auto-completion, code snippets, and project management features, all tailored for the seamless development experience with MicroPython on Raspberry Pi Pico and Pico W microcontrollers.
 
@@ -21,7 +21,7 @@ Works with:
 - Built-in virtual-workspace provider for Raspberry Pi `Pico (W)` boards (does disable Pylance auto-completion)
 - Switch between auto-completion and IntelliSense for MicroPython ports `RPi Pico`, `RPi Pico (W)` and `ESP32` (requires pip installed an in PATH)
 - Device Manager UI for managing wifi connection and installing mip packages (only on `Pico-W`; experimental)
-- `ESP32-WROOM-32` support (experimental)
+- `ESP32-WROOM-32`, `ESP32-C3` and `Teensy 4.0` support (experimental)
 
 ![Preview](images/preview.gif)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pico-w-go",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pico-w-go",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "cpu": [
         "x64",
         "arm64",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "linux"
       ],
       "dependencies": {
-        "@paulober/pyboard-serial-com": "^3.0.2",
+        "@paulober/pyboard-serial-com": "^3.0.3",
         "axios": "^1.6.5",
         "fs-extra": "^11.2.0",
         "lodash": "^4.17.21",
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@paulober/pyboard-serial-com": {
-      "version": "3.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.0.2/60b913b153da6f80ac3fdfad417f6cead9741bfe",
-      "integrity": "sha512-AxMnDOMoMHzr1t1g/xYJtwir6AYYKR/OJkJKyURXX3RVd3ig/xqag4W/r4Ct0qQyLe4UdNoAQOl3fhejppeDbg==",
+      "version": "3.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.0.3/5c06445a11491d7b402e60fc15f7f7e11d425d37",
+      "integrity": "sha512-imICqTi8VwzXTRZDMTtXfz2MyrBHMLIjuTUZj2mi0M6h/qKPPC0PoIfWEkxIaynxH+izWnX69UX3zlN1jFe8OQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^9.0.1"
@@ -3884,9 +3884,9 @@
       }
     },
     "@paulober/pyboard-serial-com": {
-      "version": "3.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.0.2/60b913b153da6f80ac3fdfad417f6cead9741bfe",
-      "integrity": "sha512-AxMnDOMoMHzr1t1g/xYJtwir6AYYKR/OJkJKyURXX3RVd3ig/xqag4W/r4Ct0qQyLe4UdNoAQOl3fhejppeDbg==",
+      "version": "3.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.0.3/5c06445a11491d7b402e60fc15f7f7e11d425d37",
+      "integrity": "sha512-imICqTi8VwzXTRZDMTtXfz2MyrBHMLIjuTUZj2mi0M6h/qKPPC0PoIfWEkxIaynxH+izWnX69UX3zlN1jFe8OQ==",
       "requires": {
         "uuid": "^9.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pico-w-go",
   "displayName": "MicroPico",
   "description": "Auto-completion, remote workspace and a REPL console integration for the Raspberry Pi Pico (W) with MicroPython firmware.",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "publisher": "paulober",
   "license": "MPL-2.0",
   "homepage": "https://github.com/paulober/MicroPico/blob/main/README.md",

--- a/package.json
+++ b/package.json
@@ -607,7 +607,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@paulober/pyboard-serial-com": "^3.0.2",
+    "@paulober/pyboard-serial-com": "^3.0.3",
     "axios": "^1.6.5",
     "fs-extra": "^11.2.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
### Added
- `ESP32-C3` and `Teensy 4.0` support (experimental) (Fixes #96)