### PR TITLE
Fix #227, Switch stubs error

### DIFF
--- a/src/activator.mts
+++ b/src/activator.mts
@@ -1122,9 +1122,7 @@ export default class Activator {
             // Map each value to "key - value" and push to resultArray
             versions.push(
               ...values.map(value =>
-                Object.keys(availableStubVersions).length > 1
-                  ? `${stubPortToDisplayString(key)} - ${value}`
-                  : value
+                `${stubPortToDisplayString(key)} - ${value}`
               )
             );
           });

--- a/src/activator.mts
+++ b/src/activator.mts
@@ -1122,7 +1122,13 @@ export default class Activator {
             // Map each value to "key - value" and push to resultArray
             versions.push(
               ...values.map(value =>
-                `${stubPortToDisplayString(key)} - ${value}`
+                // differentiate between multiple stub ports and single
+                // to reduce UI clutter for version selection
+                // after a user selected a certain port already
+                // but still support multiple ports per selection
+                Object.keys(availableStubVersions).length > 1
+                  ? `${stubPortToDisplayString(key)} - ${value}`
+                  : value
               )
             );
           });
@@ -1147,12 +1153,16 @@ export default class Activator {
             async (progress, token) => {
               // cancellation is not possible
               token.onCancellationRequested(() => undefined);
-              const versionParts = version.split(" - ");
+              const versionParts = version.includes(" - ")
+                ? version.split(" - ")
+                : [Object.keys(availableStubVersions)[0], version];
 
               // TODO: implement cancellation
               const result = await installStubsByVersion(
                 versionParts[1],
-                displayStringToStubPort(versionParts[0]),
+                version.includes(" - ")
+                  ? displayStringToStubPort(versionParts[0])
+                  : versionParts[0],
                 settings
               );
 


### PR DESCRIPTION
In the class Activator method activate, the conditional expression was omitted so that the variable versions is always a list with elements of the form "key - value".

(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.

Perhaps the cause of issue #227 is that in the following code (`activator.mts`, lines 1121-1130), the value of `Object.keys( availableStubVersions).length` is always 1 because the type of `availableStubVersions` is `{[key: string]: string[]}`.

```TypeScript
          Object.entries(availableStubVersions).forEach(([key, values]) => {
            // Map each value to "key - value" and push to resultArray
            versions.push(
              ...values.map(value =>
                Object.keys(availableStubVersions).length > 1
                  ? `${stubPortToDisplayString(key)} - ${value}`
                  : value
              )
            );
          });
```

The following is the change in this pull-request. 
This makes variable `versions` always a list with elements of the form "key - value".

```TypeScript
          Object.entries(availableStubVersions).forEach(([key, values]) => {
            // Map each value to "key - value" and push to resultArray
            versions.push(
              ...values.map(value =>
                `${stubPortToDisplayString(key)} - ${value}`
              )
            );
          });
```

## Does this close any currently open issues?

#227 

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*

Can be found in #227 

## Any other comments?


## Where has this been tested?

```
Version: 1.90.2 (Universal)
Commit: 5437499feb04f7a586f677b155b039bc2b3669eb
Date: 2024-06-18T22:37:41.291Z
Electron: 29.4.0
ElectronBuildId: 9728852
Chromium: 122.0.6261.156
Node.js: 20.9.0
V8: 12.2.281.27-electron.0
OS: Darwin arm64 23.5.0
```
