### PR TITLE
Patch v3.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the "MicroPico" extension will be documented in this file
 
 ---
 
-## [3.8.3] - 2024-08-28
+## [3.8.3] / [3.8.4] - 2024-08-29
 
 ### Added
 
@@ -18,7 +18,7 @@ All notable changes to the "MicroPico" extension will be documented in this file
 
 ### Changed
 
-- Upraded to `pyboard-serial-com` `v3.1.1`
+- Upraded to `pyboard-serial-com` `v3.1.2`
 - Updated dependencies
 - Ignore `.idea` by default (Thanks to @Finnomator for #237) 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pico-w-go",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pico-w-go",
-      "version": "3.8.3",
+      "version": "3.8.4",
       "cpu": [
         "x64",
         "arm64",
@@ -20,7 +20,7 @@
         "linux"
       ],
       "dependencies": {
-        "@paulober/pyboard-serial-com": "^3.1.1",
+        "@paulober/pyboard-serial-com": "^3.1.2",
         "axios": "^1.7.4",
         "fs-extra": "^11.2.0",
         "lodash": "^4.17.21",
@@ -312,9 +312,9 @@
       }
     },
     "node_modules/@paulober/pyboard-serial-com": {
-      "version": "3.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.1.1/7378fa4157ab2d48a0ac073505e759ee895b93cb",
-      "integrity": "sha512-kIyJN/yLF9XgKzDTX0qb/FdCoANt/7/AySNZRVgxjk+KxQwhqczpWXoNxRgaZ8PF9EqQh1egb4OSp/4KmWOzdA==",
+      "version": "3.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.1.2/a24a3d991d14271ecbc1c230baecab8064f41945",
+      "integrity": "sha512-UFA/jM4Jtg9gsk3/dHz9t/ig4aCd/Uu95lnd6RcYfChYNQW/W8m3Wmaa2D/+5fGH0sbio6RGh8MBqMEnGu5WuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "uuid": "^10.0.0"
@@ -4313,9 +4313,9 @@
       }
     },
     "@paulober/pyboard-serial-com": {
-      "version": "3.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.1.1/7378fa4157ab2d48a0ac073505e759ee895b93cb",
-      "integrity": "sha512-kIyJN/yLF9XgKzDTX0qb/FdCoANt/7/AySNZRVgxjk+KxQwhqczpWXoNxRgaZ8PF9EqQh1egb4OSp/4KmWOzdA==",
+      "version": "3.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@paulober/pyboard-serial-com/3.1.2/a24a3d991d14271ecbc1c230baecab8064f41945",
+      "integrity": "sha512-UFA/jM4Jtg9gsk3/dHz9t/ig4aCd/Uu95lnd6RcYfChYNQW/W8m3Wmaa2D/+5fGH0sbio6RGh8MBqMEnGu5WuQ==",
       "requires": {
         "uuid": "^10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pico-w-go",
   "displayName": "MicroPico",
   "description": "Auto-completion, remote workspace and a REPL console integration for the Raspberry Pi Pico (W) with MicroPython firmware.",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "publisher": "paulober",
   "license": "MPL-2.0",
   "homepage": "https://github.com/paulober/MicroPico/blob/main/README.md",
@@ -608,7 +608,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@paulober/pyboard-serial-com": "^3.1.1",
+    "@paulober/pyboard-serial-com": "^3.1.2",
     "axios": "^1.7.4",
     "fs-extra": "^11.2.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
### Added

- Eperimental support for `ESP32-S3-Pico`

### Changed

- Upraded to `pyboard-serial-com` `v3.1.2`
- Updated dependencies
- Ignore `.idea` by default (Thanks to @Finnomator for #237) 

(Fixes #244 )