### PR TITLE
Rename 'Setup MicroPico Project' to 'Initialize'

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       },
       {
         "command": "micropico.initialise",
-        "title": "Setup MicroPico project",
+        "title": "Initialize MicroPico project",
         "enablement": "(resourceScheme != pico && isFileSystemResource) || inQuickOpen",
         "category": "MicroPico"
       },


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Resolves the discussion in Issue #260.

Initialize is clearly the correct verb that describes what this button does. "Setup" and "Configure" both infer that there are options (which there are not). 

It seems that the author of the Javascript function even agrees with me, as the function this button calls is named `micropico.initialise`.

## Does this close any currently open issues?
Issue #260
