### PR TITLE
Changed toggle() to value()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pin = Pin("LED", Pin.OUT)
 print("LED starts flashing...")
 while True:
     try:
-        pin.toggle()
+        pin.value(not pin.value())
         sleep(1) # sleep 1sec
     except KeyboardInterrupt:
         break


### PR DESCRIPTION
The function toggle() is not universal, the ESP32 cannot use it.

(Hi! 👋 Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

## What does this implement/fix? Explain your changes.
toggle() is only available on the "mimxrt, samd, rp2 ports."

## Does this close any currently open issues?
No

## Any relevant logs, error output, etc?
*(If it’s long, please paste to https://gist.github.com and insert the link here)*
No

## Any other comments?
Flashing MicroPython using webserial is very easy. 
You might want to add a few lines about webserial in the requirements. 

## Where has this been tested?

**Operating system:**
Windows 11 24H2

**VSCode version:**
V1.96.4